### PR TITLE
Set the network monitor min width to 5em.

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -9,7 +9,7 @@
     padding-left: 3px;
     font-size: 10px;
     text-align: right;
-    min-width: 3em;
+    min-width: 5em;
 }
 
 .meter {


### PR DESCRIPTION
This prevents the other indicators from moving left and right as the number
of digits shown in the network indicator changes.