### PR TITLE
Add minimal installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ TopHat is an elegant system resource monitor for the GNOME shell. It displays CP
 <img src="./screenshots/mem.png?raw=true" width="360px" alt="Screenshot of memory usage indicator">
 <img src="./screenshots/net.png?raw=true" width="360px" alt="Screenshot of network usage indicator">
 
+## Installation
+
+Install TopHat from the [GNOME Shell extensions page](https://extensions.gnome.org/extension/5219/tophat/).
+
 ## Requirements
 
 - GNOME 3.38 or newer


### PR DESCRIPTION
I guess we all know how to install extensions, but I think it's still nice to have a link one can click to go there directly.