### PR TITLE
Fix horizontal display bug

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -54,13 +54,9 @@ var TopHatNetIndicator = GObject.registerClass(
             let vbox = new St.BoxLayout({ vertical: true });
             hbox.add_child(vbox);
 
-            let valueNetUp = new St.Label({ text: '0', style_class: 'value-net' });
-            vbox.add_child(valueNetUp);
-            this.valueNetUp = valueNetUp;
-
-            let valueNetDown = new St.Label({ text: '0', style_class: 'value-net' });
-            vbox.add_child(valueNetDown);
-            this.valueNetDown = valueNetDown;
+            let valueNet = new St.Label({ text: '0', style_class: 'value-net' });
+            vbox.add_child(valueNet);
+            this.valueNet = valueNet;
 
             // Initialize libgtop values
             this.net = new GTop.glibtop_netload();
@@ -169,8 +165,7 @@ var TopHatNetIndicator = GObject.registerClass(
             this.netPrev.bytes_out = bytesOut;
             let netIn = bytesToHumanString(Math.round(bytesInDelta / timeDelta));
             let netOut = bytesToHumanString(Math.round(bytesOutDelta / timeDelta));
-            this.valueNetDown.text = `${netIn}/s`;
-            this.valueNetUp.text = `${netOut}/s`;
+            this.valueNet.text = `${netOut}/s\n${netIn}/s`;
             this.menuNetDown.text = `${netIn}/s`;
             this.menuNetUp.text = `${netOut}/s`;
             // log(`[TopHat] Net: bytes_in=${(bytesInDelta / timeDelta).toFixed(2)}/s bytes_out=${(bytesOutDelta / timeDelta).toFixed(2)}/s time=${timeDelta}`);


### PR DESCRIPTION
This might only be an issue for people who use heavy top bar modifications but sometimes the readouts aren't stacked vertically like they're supposed to be. Fixed it by consolidating valueNetDown and valueNetUp into one element. 