### PR TITLE
Avoid displaying an used swap of NaN%

### DIFF
--- a/lib/mem.js
+++ b/lib/mem.js
@@ -76,7 +76,10 @@ class MemUse {
     }
 
     get swap() {
-        return (this._swapUsed / this._swapSize).toFixed(2);
+        if (this.swapUsed === 0 || this.swapSize === 0) {
+            return 0;
+        }
+        return (this.swapUsed / this.swapSize).toFixed(2);
     }
 
     get swapUsed() {


### PR DESCRIPTION
Hello,

I do not have any swap (32 GB of RAM is sufficient for me), and TopHat displays a swap usage of `NaN%`:

![Capture d’écran du 2022-12-28 10-15-51](https://user-images.githubusercontent.com/971438/209790002-61f5f029-0c09-4dad-8e06-8d5d935f5864.png)

This PR contains a simple fix to avoid this behavior.

A better solution would be to hide swap statistics if there is no swap (I can try to implement it if you think it is a better solution).