### PR TITLE
Add support for AMD CPU temp reading using k10temp

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,10 @@
 All notable changes to [TopHat] are listed in this file. The format is loosely
 based on [Keep a Changelog].
 
+## Not yet released
+
+- Fixed problem reading temperatures from AMD CPUs (from [@theizzer](https://github.com/theizzer))
+
 ## TopHat 6 - December 27, 2022
 
 - Added CPU model, clock speed, and temperature to processor menu

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -225,7 +225,6 @@ var CpuMonitor = GObject.registerClass({
                             inputPath = `${basePath}${file}/temp1_input`;
                         }
                         this.cpuTempMonitors.set(0, inputPath);
-
                     }
                 }
                 resolve(this.cpuTempMonitors.size > 0);

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -207,7 +207,7 @@ var CpuMonitor = GObject.registerClass({
                 for (let file of files) {
                     const path = `${basePath}${file}/name`;
                     const name = new FileModule.File(path).readSync();
-                    // CPU should be named 'coretemp'
+                    // CPU should be named 'coretemp' for Intel CPUs or "k10temp" for AMD CPUs
                     if (name === 'coretemp') {
                         // determine which processor (socket) we are dealing with
                         const prefix = new FileModule.File(`${basePath}${file}/temp1_label`).readSync();
@@ -217,6 +217,15 @@ var CpuMonitor = GObject.registerClass({
                         }
                         const inputPath = `${basePath}${file}/temp1_input`;
                         this.cpuTempMonitors.set(id, inputPath);
+                    } else if (name === 'k10temp') {
+                        // AMD Processors (temp2 is Tdie, temp1 is Tctl)
+                        let inputPath = `${basePath}${file}/temp2_input`;
+                        const f = new FileModule.File(inputPath);
+                        if (!f.exists()) {
+                            inputPath = `${basePath}${file}/temp1_input`;
+                        }
+                        this.cpuTempMonitors.set(0, inputPath);
+
                     }
                 }
                 resolve(this.cpuTempMonitors.size > 0);

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -224,6 +224,8 @@ var CpuMonitor = GObject.registerClass({
                         if (!f.exists()) {
                             inputPath = `${basePath}${file}/temp1_input`;
                         }
+                        // FIXME: Instead of key=0 here, try to figure out which physical CPU
+                        // this monitor represents
                         this.cpuTempMonitors.set(0, inputPath);
                     }
                 }


### PR DESCRIPTION
I've noticed while using this extension that it was not showing temperature reading for me. So I decided to investigate and came up with this.

This adds support for temperature reading for AMD processors using 'k10temp' kernel driver. It only shows one (Tctl) or two temps (Tctl & Tdie - for newer CPUs that support it) for the whole CPU so I wrote it that it shows the more accurate reading (Tdie) with Tctl reading as a fallback.

![image](https://user-images.githubusercontent.com/7683810/210852946-56a0c0f2-cfde-47d7-908a-1fee58322f04.png)

Now I am happy :)