### PR TITLE
Add support for Gnome 46

### DIFF
--- a/tophat@fflewddur.github.io/lib/cpu.js
+++ b/tophat@fflewddur.github.io/lib/cpu.js
@@ -613,11 +613,11 @@ export const CpuMonitor = GObject.registerClass({
         [, fg] = Clutter.Color.from_string(this.meter_fg_color);
         [, bg] = Clutter.Color.from_string(Config.METER_BG_COLOR);
 
-        Clutter.cairo_set_source_color(ctx, bg);
+        Shared.setSourceColor(ctx, bg);
         ctx.rectangle(0, 0, width, height);
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, fg);
+        Shared.setSourceColor(ctx, fg);
         ctx.moveTo(xStart, height);
         for (let i = 0; i < this.history.length; i++) {
             let pointHeight = Math.ceil(this.history[i].total() / 100.0 * height);

--- a/tophat@fflewddur.github.io/lib/fs.js
+++ b/tophat@fflewddur.github.io/lib/fs.js
@@ -514,15 +514,15 @@ export const FileSystemMonitor = GObject.registerClass({
         this.historyMaxVal.text = `${Shared.bytesToHumanString(max, 'bytes', true)}/s`;
         max *= 2; // leave room for both upload and download speeds on the same chart
 
-        Clutter.cairo_set_source_color(ctx, bg);
+        Shared.setSourceColor(ctx, bg);
         ctx.rectangle(0, 0, width, height);
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, gc);
+        Shared.setSourceColor(ctx, gc);
         ctx.rectangle(0, height / 2, width, 1);
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, fg);
+        Shared.setSourceColor(ctx, fg);
         ctx.moveTo(xStart, height);
         for (let i = 0; i < this.history.length; i++) {
             let pointHeight = Math.ceil(this.history[i].read / max * height);
@@ -534,7 +534,7 @@ export const FileSystemMonitor = GObject.registerClass({
         ctx.closePath();
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, fg);
+        Shared.setSourceColor(ctx, fg);
         ctx.moveTo(xStart, 0);
         for (let i = 0; i < this.history.length; i++) {
             let pointHeight = Math.ceil(this.history[i].write / max * height);

--- a/tophat@fflewddur.github.io/lib/mem.js
+++ b/tophat@fflewddur.github.io/lib/mem.js
@@ -420,11 +420,11 @@ export const MemMonitor = GObject.registerClass(
             [, fg] = Clutter.Color.from_string(this.meter_fg_color);
             [, bg] = Clutter.Color.from_string(Config.METER_BG_COLOR);
 
-            Clutter.cairo_set_source_color(ctx, bg);
+            Shared.setSourceColor(ctx, bg);
             ctx.rectangle(0, 0, width, height);
             ctx.fill();
 
-            Clutter.cairo_set_source_color(ctx, fg);
+            Shared.setSourceColor(ctx, fg);
             ctx.moveTo(xStart, height);
             for (let i = 0; i < this.history.length; i++) {
                 let pointHeight = Math.ceil(this.history[i].mem * height);

--- a/tophat@fflewddur.github.io/lib/monitor.js
+++ b/tophat@fflewddur.github.io/lib/monitor.js
@@ -248,7 +248,7 @@ export const TopHatMonitor = GObject.registerClass({
             this.menu.connect('open-state-changed', this._onOpenStateChanged.bind(this));
             this.menu.actor.connect('key-press-event', this._onMenuKeyPress.bind(this));
 
-            Main.uiGroup.add_actor(this.menu.actor);
+            Main.uiGroup.add_child(this.menu.actor);
             this.menu.actor.hide();
         }
         this.emit('menu-set');

--- a/tophat@fflewddur.github.io/lib/net.js
+++ b/tophat@fflewddur.github.io/lib/net.js
@@ -257,15 +257,15 @@ export const NetMonitor = GObject.registerClass({
         this.historyMaxVal.text = `${Shared.bytesToHumanString(max, 'bytes', true)}/s`;
         max *= 2; // leave room for both upload and download speeds on the same chart
 
-        Clutter.cairo_set_source_color(ctx, bg);
+        Shared.setSourceColor(ctx, bg);
         ctx.rectangle(0, 0, width, height);
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, gc);
+        Shared.setSourceColor(ctx, gc);
         ctx.rectangle(0, height / 2, width, 1);
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, fgDown);
+        Shared.setSourceColor(ctx, fgDown);
         ctx.moveTo(xStart, height);
         for (let i = 0; i < this.history.length; i++) {
             let pointHeight = Math.ceil(this.history[i].down / max * height);
@@ -277,7 +277,7 @@ export const NetMonitor = GObject.registerClass({
         ctx.closePath();
         ctx.fill();
 
-        Clutter.cairo_set_source_color(ctx, fgUp);
+        Shared.setSourceColor(ctx, fgUp);
         ctx.moveTo(xStart, 0);
         for (let i = 0; i < this.history.length; i++) {
             let pointHeight = Math.ceil(this.history[i].up / max * height);

--- a/tophat@fflewddur.github.io/lib/shared.js
+++ b/tophat@fflewddur.github.io/lib/shared.js
@@ -19,6 +19,7 @@
 
 import Gio from 'gi://Gio';
 import GTop from 'gi://GTop';
+import Clutter from 'gi://Clutter';
 
 export const SECOND_AS_MICROSECONDS = 1000000;
 export const SECOND_AS_MILLISECONDS = 1000;
@@ -181,4 +182,22 @@ export function getPartitions() {
     mounts = Array.from(mountMap.values());
     // console.debug(`[TopHat] mounts = ${mounts}`);
     return mounts;
+}
+
+/**
+ * Sets source color for given context element using:
+ * - setSourceColor for Gnome 46 and later
+ * - cairo_set_source_color for Gnome 45
+ *
+ * @param {cairo.Context} ctx - Context element to set color on
+ * @param {Clutter.Color} color - Color to set
+ */
+export function setSourceColor(ctx, color) {
+    if (ctx.setSourceColor) {
+        // Use new color setting if available
+        ctx.setSourceColor(color);
+    } else {
+        // Fall back to old ways
+        Clutter.cairo_set_source_color(ctx, color);
+    }
 }

--- a/tophat@fflewddur.github.io/metadata.json
+++ b/tophat@fflewddur.github.io/metadata.json
@@ -3,7 +3,7 @@
     "name": "TopHat",
     "description": "View CPU, memory, disk, and network activity in the GNOME top bar.",
     "version": 13,
-    "shell-version": [ "45" ],
+    "shell-version": [ "45", "46" ],
     "url": "https://github.com/fflewddur/tophat",
     "gettext-domain": "tophat@fflewddur.github.io",
     "settings-schema": "org.gnome.shell.extensions.tophat"


### PR DESCRIPTION
Fixes:
- `Clutter.cairo_set_source_color` is not a function. This is due too dropped support for `Clutter.cairo` helpers:
https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-cairo-hellpers
- `Clutter.Container` was removed resulting in `add_actor` failing. Moved to `add_child`:
https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-container


Tested on Gnome 45 (On Fedora):
![image](https://github.com/fflewddur/tophat/assets/11278533/46f7903e-0835-4150-8f88-c2461872164a)

Tested on Gnome 46 (On Arch):
![image](https://github.com/fflewddur/tophat/assets/11278533/3b3d90b8-4d90-4263-860d-09100e088584)

