### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -1,5 +1,7 @@
 name: ESLint
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fflewddur/tophat/security/code-scanning/1](https://github.com/fflewddur/tophat/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read-only operations (checking out code and running ESLint), the minimal permissions required are `contents: read`. This ensures that the workflow has the least privilege necessary to complete its tasks.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs within the workflow. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
