### PR TITLE
Add CPU temps in top bar

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tophat.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tophat.gschema.xml
@@ -118,6 +118,11 @@
       <summary>How frequently TopHat will check system resource usage</summary>
       <description>This controls how frequently Tophat will check system resource usage. 'fast' will update more often but may negatively impact system performance. 'slow' will update less often and may improve system performance.</description>
     </key>
+    <key name="show-cpu-temp" type="b">
+      <default>true</default>
+      <summary>Display CPU temp on the top bar</summary>
+      <description>When true, the CPU temperature will be shown alongside the CPU usage in the top bar.</description>
+    </key>
     <key name="cpu-show-cores" type="b">
       <default>true</default>
       <summary>Show a meter bar for each CPU core</summary>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -13,7 +13,7 @@
   spacing: 2em;
 }
 
-.tophat-menu-button-box > StButton {
+.tophat-menu-button-box>StButton {
   border-radius: 2em;
   margin: 0;
   padding: 0.7em;
@@ -21,16 +21,16 @@
   min-width: 0.5em;
 }
 
-.tophat-menu-button-box > StButton > StIcon {
+.tophat-menu-button-box>StButton>StIcon {
   icon-size: 1.25em;
   -st-icon-style: symbolic;
 }
 
 .tophat-panel-usage {
-  text-align: center;
+  text-align: left;
   min-width: 2.1em;
   font-size: 0.9em;
-  margin: 0 6px 0 0;
+  margin: 0 2px 0 2px;
   padding: 0;
 }
 
@@ -46,6 +46,14 @@
   font-size: 0.7em;
   text-align: right;
   min-width: 5em;
+}
+
+.tophat-panel-temp {
+  text-align: center;
+  min-width: 2.1em;
+  font-size: 0.9em;
+  margin: 0 2px 0 2px;
+  padding: 0;
 }
 
 .tophat-panel-inactive {
@@ -194,7 +202,7 @@
   margin: 0;
 }
 
-.tophat-tooltip > StLabel {
+.tophat-tooltip>StLabel {
   font-size: 0.8em;
   text-align: center;
   padding: 3px 6px;

--- a/run-nested-shell.sh
+++ b/run-nested-shell.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+# export G_MESSAGES_DEBUG=all
+export MUTTER_DEBUG_DUMMY_MODE_SPECS=1280x720
+# export SHELL_DEBUG=all
+
+dbus-run-session -- \
+    gnome-shell --nested \
+                --wayland

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -37,6 +37,7 @@ export const CpuMonitor = GObject.registerClass(
   class CpuMonitor extends TopHatMonitor {
     private usage;
     private temp;
+    private showTemp;
     private menuCpuUsage;
     private menuCpuCap;
     private menuCpuModel;
@@ -69,7 +70,31 @@ export const CpuMonitor = GObject.registerClass(
         style_class: 'tophat-panel-usage tophat-panel-usage-wider',
         y_align: Clutter.ActorAlign.CENTER,
       });
-      this.add_child(this.temp);
+
+      this.showTemp = gsettings.get_boolean('show-cpu-temp');
+      if (this.showTemp) {
+        this.add_child(this.temp);
+      }
+
+      let id = this.gsettings.connect('changed::show-cpu-temp', (settings) => {
+        this.showTemp = settings.get_boolean('show-cpu-temp');
+
+        if (this.showTemp) {
+          if (!this.temp.get_parent()) {
+            this.temp = new St.Label({  // recreate if destroyed
+              text: MeterNoVal,
+              style_class: 'tophat-panel-temp tophat-panel-usage-wider',
+              y_align: Clutter.ActorAlign.CENTER,
+            });
+            this.add_child(this.temp);
+          }
+        } else {
+          if (this.temp.get_parent()) {
+            this.temp.destroy();
+          }
+        }
+      });
+      this.settingsSignals.push(id);
 
       this.meter.setNumBars(1);
       this.meter.setOrientation(Orientation.Vertical);
@@ -88,7 +113,7 @@ export const CpuMonitor = GObject.registerClass(
       }
 
       this.showCores = this.gsettings.get_boolean('cpu-show-cores');
-      let id = this.gsettings.connect('changed::cpu-show-cores', (settings) => {
+      id = this.gsettings.connect('changed::cpu-show-cores', (settings) => {
         this.showCores = settings.get_boolean('cpu-show-cores');
         if (!this.showCores) {
           this.meter.setNumBars(1);

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -36,6 +36,7 @@ import { CapacityBar } from './capacity.js';
 export const CpuMonitor = GObject.registerClass(
   class CpuMonitor extends TopHatMonitor {
     private usage;
+    private temp;
     private menuCpuUsage;
     private menuCpuCap;
     private menuCpuModel;
@@ -62,6 +63,13 @@ export const CpuMonitor = GObject.registerClass(
         y_align: Clutter.ActorAlign.CENTER,
       });
       this.add_child(this.usage);
+
+      this.temp = new St.Label({
+        text: MeterNoVal,
+        style_class: 'tophat-panel-usage tophat-panel-usage-wider',
+        y_align: Clutter.ActorAlign.CENTER,
+      });
+      this.add_child(this.temp);
 
       this.meter.setNumBars(1);
       this.meter.setOrientation(Orientation.Vertical);
@@ -266,6 +274,7 @@ export const CpuMonitor = GObject.registerClass(
       id = vitals.connect('notify::cpu-temp', () => {
         // console.log(`cpu-temp: ${vitals.cpu_temp}`);
         const s = vitals.cpu_temp.toFixed(0) + ' °C';
+        this.temp.text = s;
         this.menuCpuTemp.text = s;
       });
       this.vitalsSignals.push(id);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -143,6 +143,9 @@ export default class TopHatPrefs extends ExtensionPreferences {
     choices.append(_('Both meter and value'));
     this.addComboRow(_('Show as'), choices, 'cpu-display', group);
 
+    // Show temps
+    this.addActionRow(_('Show temperature'), 'show-cpu-temp', group);
+
     // Show each core
     this.addActionRow(_('Show each core'), 'cpu-show-cores', group);
 

--- a/src/vitals.ts
+++ b/src/vitals.ts
@@ -310,6 +310,7 @@ export const Vitals = GObject.registerClass(
     private fsLoop = 0;
     private groupRelated;
     private showCpu;
+    private showCpuTemp;
     private showMem;
     private showNet;
     private showDisk;
@@ -369,6 +370,15 @@ export const Vitals = GObject.registerClass(
         'changed::show-cpu',
         (settings: Gio.Settings) => {
           this.showCpu = settings.get_boolean('show-cpu');
+        }
+      );
+      this.settingSignals.push(id);
+
+      this.showCpuTemp = gsettings.get_boolean('show-cpu-temp');
+      id = this.gsettings.connect(
+        'changed::show-cpu-temp',
+        (settings: Gio.Settings) => {
+          this.showCpuTemp = settings.get_boolean('show-cpu-temp');
         }
       );
       this.settingSignals.push(id);
@@ -510,6 +520,9 @@ export const Vitals = GObject.registerClass(
     public readSummaries(): boolean {
       if (this.showCpu) {
         this.loadStat();
+        if (this.showCpuTemp) {
+          this.loadTemps();
+        }
       }
       if (this.showMem) {
         this.loadMeminfo();
@@ -931,7 +944,7 @@ export const Vitals = GObject.registerClass(
             curProcs.set(p.id, p);
             p.setTotalTime(
               this.cpuState.totalTimeDetails -
-                this.cpuState.totalTimeDetailsPrev
+              this.cpuState.totalTimeDetailsPrev
             );
             const actions = [];
             actions.push(this.loadCmdForProcess(p));
@@ -1995,7 +2008,7 @@ class DiskState {
     }
     const retval = Math.round(
       (this.bytesWritten - this.bytesWrittenPrev) /
-        ((this.ts - this.tsPrev) / 1000)
+      ((this.ts - this.tsPrev) / 1000)
     );
     // console.log(`returning writeActivity: ${retval}`);
     return retval;


### PR DESCRIPTION
This contribution aims to add showing CPU temps in the topbar, as I believe it is as important to show as CPU usage.
Additionally, a helper shell script was created to help streamline debugging in wayland.

Screenshot : 
<img width="1595" height="297" alt="image" src="https://github.com/user-attachments/assets/a7710097-be01-4321-aadc-b30f479f2f25" />